### PR TITLE
Release 2.3.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,66 @@
   version = "v1.0.3"
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "629574ca2a5df945712d3079857300b5e4da0236"
+  version = "v1.4.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/hcl"
+  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  revision = "68e816d1c783414e79bc65b3994d9ab6b0a722ab"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
+  version = "v1.7.3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  revision = "d0303fe809921458f417bcf828397a65db30a7e4"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
+  version = "v1.0.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/spf13/afero"
+  packages = [".","mem"]
+  revision = "ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
@@ -19,9 +79,21 @@
   packages = ["unix","windows"]
   revision = "314a259e304ff91bd6985da2a7149bbf91237993"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/text"
+  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
+
+[[projects]]
+  branch = "v2"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6b1e5eb6523d15d8e15970007274b8b5fc722bf13c302df54bc2df97cac14ccd"
+  inputs-digest = "178ec4e046465041cd85bc0f197c970e5d09be6071736798e095063bd6b01786"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -25,9 +25,19 @@ There are three ways to install DVM, but if you're at all familiar with Golang t
 1. run `go get -u github.com/fubarhouse/dvm/...`
 2. Build your own Go binary using the API's from the packages downloaded.
 
-## Option 3
+### Option 3
 1. Download the pre-compiled binaries.
 2. Copy to location in $PATH environment variable.
+
+## Configuration
+Configurations are loaded via Viper, an example is below.
+
+The default values are in this example and should be overriden in `~/.dvm/config.toml` to suit your system.
+
+```
+[config]
+path = "/usr/local/bin/drush"
+```
 
 ## DVM Usage
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ There are three ways to install DVM, but if you're at all familiar with Golang t
 2. Build your own Go binary using the API's from the packages downloaded.
 
 ### Option 3
-1. Download the pre-compiled binaries.
+1. Download the [pre-compiled binaries](https://github.com/fubarhouse/dvm/releases).
 2. Copy to location in $PATH environment variable.
 
 ## Configuration

--- a/cmd/dvm/main.go
+++ b/cmd/dvm/main.go
@@ -14,23 +14,24 @@ import (
 	"github.com/spf13/viper"
 )
 
-// @TODO: Use git tags to discover content dynamically?
-
 // print_usage provides the user with examples of application usage.
 func print_usage() {
 	fmt.Println("Example usages:")
 	fmt.Println("-")
-	fmt.Println("dvm install 7.0.0\t\t\tInstall a specified version of Drush")
-	fmt.Println("dvm uninstall 7.0.0\t\t\tUninstall a specified version of Drush")
-	fmt.Println("dvm reinstall 7.0.0\t\t\tReinstall a specified version of Drush")
-	fmt.Println("dvm use 7.0.0\t\t\t\tSpecify the version of Drush to set as in use")
+	fmt.Println("dvm install 7.0.0\t\t\t\tInstall a specified version of Drush")
+	fmt.Println("dvm uninstall 7.0.0\t\t\t\tUninstall a specified version of Drush")
+	fmt.Println("dvm reinstall 7.0.0\t\t\t\tReinstall a specified version of Drush")
+	fmt.Println("dvm use 7.0.0\t\t\t\t\tSpecify the version of Drush to set as in use")
 	fmt.Println("-")
-	fmt.Println("dvm package install registry_rebuild\tInstall a Drush module")
-	fmt.Println("dvm package uninstall registry_rebuild\tUnistall a Drush module")
-	fmt.Println("dvm package reinstall registry_rebuild\tReistall a Drush module")
+	fmt.Println("dvm package install registry_rebuild\t\tInstall a Drush module")
+	fmt.Println("dvm package uninstall registry_rebuild\t\tUnistall a Drush module")
+	fmt.Println("dvm package reinstall registry_rebuild\t\tReistall a Drush module")
 	fmt.Println("-")
-	fmt.Println("dvm list installed\t\t\tList installed Drush versions")
-	fmt.Println("dvm list available\t\t\tList available Drush versions")
+	fmt.Println("dvm list installed\t\t\t\tList installed Drush versions")
+	fmt.Println("dvm list available\t\t\t\tList available Drush versions")
+	fmt.Println("-")
+	fmt.Println("dvm config get <config_name>\t\t\tList installed Drush versions")
+	fmt.Println("dvm config set <config_name> <config_value>\tList available Drush versions")
 }
 
 func main() {
@@ -58,44 +59,76 @@ func main() {
 			}
 		}
 	}
+
 	if os.Args != nil && len(os.Args) >= 2 {
 
 		if os.Args[1] == "install" || os.Args[1] == "uninstall" || os.Args[1] == "reinstall" || os.Args[1] == "use" {
-			Action := os.Args[1]
-			Version := os.Args[2]
-			this := version.NewDrushVersion(Version)
-			if Action == "install" {
-				this.Install()
-			} else if Action == "reinstall" {
-				this.Reinstall()
-			} else if Action == "uninstall" {
-				this.Uninstall()
-			} else if Action == "use" {
-				this.SetDefault()
-			}
-		}
-		if os.Args[1] == "package" {
-			if os.Args[2] == "install" || os.Args[2] == "uninstall" || os.Args[2] == "reinstall" {
-				Action := os.Args[2]
-				PackageName := os.Args[3]
-				this := plugin.NewDrushPackage(PackageName)
+			if len(os.Args) > 2 {
+				Action := os.Args[1]
+				Version := os.Args[2]
+				this := version.NewDrushVersion(Version)
 				if Action == "install" {
 					this.Install()
 				} else if Action == "reinstall" {
 					this.Reinstall()
 				} else if Action == "uninstall" {
 					this.Uninstall()
+				} else if Action == "use" {
+					this.SetDefault()
+				}
+			} else {
+				print_usage()
+				fmt.Println("-")
+				fmt.Println("No version argument specified.")
+				os.Exit(0)
+			}
+		}
+
+		if os.Args[1] == "package" {
+			if len(os.Args) > 2 {
+				if os.Args[2] == "install" || os.Args[2] == "uninstall" || os.Args[2] == "reinstall" {
+					if len(os.Args) > 3 {
+						Action := os.Args[2]
+						PackageName := os.Args[3]
+						this := plugin.NewDrushPackage(PackageName)
+						if Action == "install" {
+							this.Install()
+						} else if Action == "reinstall" {
+							this.Reinstall()
+						} else if Action == "uninstall" {
+							this.Uninstall()
+						}
+					}
+				} else {
+					print_usage()
+					fmt.Println("-")
+					fmt.Println("No valid package action specified.")
+					os.Exit(0)
+				}
+			} else {
+				print_usage()
+				fmt.Println("-")
+				fmt.Println("No package action specified.")
+				os.Exit(0)
+			}
+		}
+
+		if len(os.Args) > 2 {
+			if os.Args[1] == "list" {
+				Drushes := versionlist.NewDrushVersionList()
+				if os.Args[2] == "available" {
+					Drushes.PrintRemote()
+				} else if os.Args[2] == "installed" {
+					Drushes.PrintInstalled()
+				} else {
+					print_usage()
+					fmt.Println("-")
+					fmt.Println("No valid action specified.")
+					os.Exit(0)
 				}
 			}
 		}
-		if os.Args[1] == "list" {
-			Drushes := versionlist.NewDrushVersionList()
-			if os.Args[2] == "available" {
-				Drushes.PrintRemote()
-			} else if os.Args[2] == "installed" {
-				Drushes.PrintInstalled()
-			}
-		}
+
 		if os.Args[1] == "config" {
 			if os.Args[2] == "set" {
 				conf.Set(os.Args[3], os.Args[4])

--- a/cmd/dvm/main.go
+++ b/cmd/dvm/main.go
@@ -7,6 +7,8 @@ import (
 	"github.com/fubarhouse/dvm/version"
 	"github.com/fubarhouse/dvm/versionlist"
 	"os"
+
+	"github.com/fubarhouse/dvm/conf"
 )
 
 // @TODO: Use git tags to discover content dynamically?
@@ -77,6 +79,13 @@ func main() {
 				Drushes.PrintRemote()
 			} else if os.Args[2] == "installed" {
 				Drushes.PrintInstalled()
+			}
+		}
+		if os.Args[1] == "config" {
+			if os.Args[2] == "set" {
+				conf.Set("", "")
+			} else if os.Args[2] == "get" {
+
 			}
 		}
 	} else {

--- a/cmd/dvm/main.go
+++ b/cmd/dvm/main.go
@@ -3,12 +3,15 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"os/user"
+
+	"github.com/fubarhouse/dvm/conf"
 	"github.com/fubarhouse/dvm/plugin"
 	"github.com/fubarhouse/dvm/version"
 	"github.com/fubarhouse/dvm/versionlist"
-	"os"
-
-	"github.com/fubarhouse/dvm/conf"
+	"github.com/spf13/viper"
 )
 
 // @TODO: Use git tags to discover content dynamically?
@@ -32,7 +35,19 @@ func print_usage() {
 
 func main() {
 
-	_, StatErr := os.Stat("/usr/local/bin/drush")
+	x, _ := user.Current()
+	y := x.HomeDir
+	cp := y + "/.dvm"
+
+	viper.SetConfigName("config")
+	viper.AddConfigPath(cp)
+	err := viper.ReadInConfig()
+
+	if err != nil {
+		log.Println("No configuration file loaded - using defaults")
+	}
+
+	_, StatErr := os.Stat(viper.GetString("config.path"))
 	if StatErr != nil {
 		if len(os.Args) < 2 {
 			if os.Args[1] != "install" && os.Args[1] != "reinstall" && os.Args[1] != "use" {
@@ -83,7 +98,7 @@ func main() {
 		}
 		if os.Args[1] == "config" {
 			if os.Args[2] == "set" {
-				conf.Set("", "")
+				conf.Set(os.Args[3], os.Args[4])
 			} else if os.Args[2] == "get" {
 
 			}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,41 +1,47 @@
 package conf
 
 import (
-	"os"
+	"github.com/spf13/viper"
+	"log"
 	"os/user"
-	"github.com/naoina/toml"
 )
 
-type config struct {
-	Dvm struct {
-		Name string
-		Path string
-	}
-}
-
-func getSettings() *config {
+// Path will retrieve config.path from the config file.
+func Path() string {
 	x, _ := user.Current()
 	y := x.HomeDir
-	cp := y + "/.dvm/config.toml"
+	cp := y + "/.dvm"
 
-	println(cp)
-	f, err := os.Open(cp)
+	viper.SetConfigName("config")
+	viper.AddConfigPath(cp)
+	err := viper.ReadInConfig()
+
 	if err != nil {
-		panic(err)
+		log.Println("No configuration file loaded - using defaults")
+		viper.SetDefault("config.path", "/usr/local/bin/drush")
 	}
-	defer f.Close()
-	var c config
-	if err := toml.NewDecoder(f).Decode(&c); err != nil {
-		panic(err)
-	}
-	return &c;
+
+	return viper.GetString("config.path")
 }
 
-func Path() string {
-	c := getSettings()
-	return c.Dvm.Path
-}
+// Set will set a value in the config to the input.
+// Viper does not support writing to config files yet,
+// so for now this is largely useless...
+func Set(name, value string) error {
+	x, _ := user.Current()
+	y := x.HomeDir
+	cp := y + "/.dvm"
 
-func Set(name, value string) {
-	getSettings()
+	viper.SetConfigName("config")
+	viper.AddConfigPath(cp)
+	err := viper.ReadInConfig()
+
+	if err != nil {
+		log.Println("No configuration file found - cannot set configuration.")
+		return err
+	} else {
+		viper.Set(name, value)
+		log.Printf("Configuration %v was set to %v\n", name, viper.Get(name))
+		return nil
+	}
 }

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,0 +1,41 @@
+package conf
+
+import (
+	"os"
+	"os/user"
+	"github.com/naoina/toml"
+)
+
+type config struct {
+	Dvm struct {
+		Name string
+		Path string
+	}
+}
+
+func getSettings() *config {
+	x, _ := user.Current()
+	y := x.HomeDir
+	cp := y + "/.dvm/config.toml"
+
+	println(cp)
+	f, err := os.Open(cp)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	var c config
+	if err := toml.NewDecoder(f).Decode(&c); err != nil {
+		panic(err)
+	}
+	return &c;
+}
+
+func Path() string {
+	c := getSettings()
+	return c.Dvm.Path
+}
+
+func Set(name, value string) {
+	getSettings()
+}

--- a/version/version.go
+++ b/version/version.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"os/user"
 	"github.com/fubarhouse/dvm/versionlist"
+	"github.com/fubarhouse/dvm/conf"
 )
-
-const PATH_DRUSH = "/usr/local/bin/drush"
 
 // DrushVersion is a struct containing information on a given version of Drush.
 type DrushVersion struct {
@@ -184,11 +183,11 @@ func (drushVersion *DrushVersion) SetDefault() {
 	symlinkDest := ""
 	if majorVersion == "6" || majorVersion == "7" || majorVersion == "8" || majorVersion == "9" {
 		// If the version is supported by composer:
-		symlinkSource = PATH_DRUSH
+		symlinkSource = conf.Path()
 		symlinkDest = workingDir + "/drush-" + drushVersion.version + "/vendor/bin/drush"
 	} else {
 		// If it isn't supported by Composer...
-		symlinkSource = PATH_DRUSH
+		symlinkSource = conf.Path()
 		symlinkDest = workingDir + "/drush-" + drushVersion.version + "/drush"
 	}
 
@@ -196,19 +195,19 @@ func (drushVersion *DrushVersion) SetDefault() {
 		// Remove symlink
 		_, rmErr := exec.Command("sh", "-c", "rm -f "+symlinkSource).Output()
 		if rmErr != nil {
-			log.Println("Could not remove "+PATH_DRUSH+": ", rmErr)
+			log.Println("Could not remove "+conf.Path()+": ", rmErr)
 		} else {
 			log.Println("Symlink successfully removed.")
 		}
 		// Add symlink
 		_, rmErr = exec.Command("sh", "-c", "ln -sF "+symlinkDest+" "+symlinkSource).Output()
 		if rmErr != nil {
-			log.Println("Could not sym "+PATH_DRUSH+": ", rmErr)
+			log.Println("Could not sym "+conf.Path()+": ", rmErr)
 		} else {
 			log.Println("Symlink successfully created.")
 		}
 		// Verify version
-		currVer, rmErr := exec.Command("sh", "-c", PATH_DRUSH+" --version").Output()
+		currVer, rmErr := exec.Command("sh", "-c", conf.Path()+" --version").Output()
 		if rmErr != nil {
 			log.Println("Drush returned error: ", rmErr)
 			os.Exit(1)

--- a/versionlist/versions.go
+++ b/versionlist/versions.go
@@ -2,12 +2,12 @@ package versionlist
 
 import (
 	"fmt"
+	"github.com/fubarhouse/dvm/conf"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
 	"strings"
-	"github.com/fubarhouse/dvm/conf"
 )
 
 // DrushVersionList is a struct to store associated versions in a simple []string.
@@ -100,6 +100,30 @@ func (drushVersionList *DrushVersionList) PrintInstalled() {
 	for _, value := range InstalledVersions.list {
 		fmt.Println(value)
 	}
+}
+
+// GetInstalled returns a list of all installed drush versions.
+func (drushVersionList *DrushVersionList) GetInstalled() []string {
+	InstalledVersions := drushVersionList.ListInstalled()
+	var versions []string
+	for _, value := range InstalledVersions.list {
+		versions = append(versions, value)
+	}
+	return versions
+}
+
+// IsInstalled returns a boolean of the status of an input version.
+func (drushVersionList *DrushVersionList) IsInstalled(version string) bool {
+	InstalledVersions := drushVersionList.ListInstalled()
+	for _, value := range InstalledVersions.list {
+		if strings.Contains(value, version) {
+			return true
+		}
+		if strings.Contains(value, version+"*") {
+			return true
+		}
+	}
+	return false
 }
 
 // GetActiveVersion returns the currently active Command version

--- a/versionlist/versions.go
+++ b/versionlist/versions.go
@@ -7,9 +7,8 @@ import (
 	"os/exec"
 	"os/user"
 	"strings"
+	"github.com/fubarhouse/dvm/conf"
 )
-
-const PATH_DRUSH = "/usr/local/bin/drush"
 
 // DrushVersionList is a struct to store associated versions in a simple []string.
 // This is used by methods to store and use multiple version data.
@@ -105,7 +104,7 @@ func (drushVersionList *DrushVersionList) PrintInstalled() {
 
 // GetActiveVersion returns the currently active Command version
 func GetActiveVersion() string {
-	drushOutputVersion, drushOutputError := exec.Command(PATH_DRUSH, "version", "--format=string").Output()
+	drushOutputVersion, drushOutputError := exec.Command(conf.Path(), "version", "--format=string").Output()
 	if drushOutputError != nil {
 		fmt.Println(drushOutputError)
 		os.Exit(1)


### PR DESCRIPTION
* Introduces support for dep #93
* Introduces support for viper; and configurable path to drush #90
* Introduces checks when attempting to `use` a version #91 
* Fixes the fatal errors when invalid or empty arguments are provided to CLI #94 
* Adds a link to the release page from the readme #92 